### PR TITLE
Reinvigorate github actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,9 +13,24 @@ env:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: Build and test for ${{matrix.rust}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust:
+          - 1.84.1 # pre edition2024
+          - stable
     steps:
     - uses: actions/checkout@v2
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{matrix.rust}}
+        override: true
+
     - name: Build lib
       run: cargo build --verbose
     - name: Run tests
@@ -24,13 +39,21 @@ jobs:
       run: cargo build --example '*'
 
   style:
-    runs-on: ubuntu-latest
+    name: Style checks for ${{matrix.rust}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        rust:
+          - 1.84.1 # pre edition2024
+          - stable
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{matrix.rust}}
           override: true
           components: rustfmt, clippy
       - name: fmt

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # allow manual trigger
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,6 +21,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust:
           - 1.84.1 # pre edition2024
+          - 1.87
           - stable
     steps:
     - uses: actions/checkout@v2
@@ -47,7 +48,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust:
           - 1.84.1 # pre edition2024
-          - stable
+          - 1.87   # pre format-style clippy
+          # - stable
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,8 +48,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust:
           - 1.84.1 # pre edition2024
-          - 1.87   # pre format-style clippy
-          # - stable
+          - 1.87   # clippy became more picky after this
+          - stable
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -235,7 +235,6 @@ fn is_next_header(input: Input<'_>) -> bool {
         || input.starts_with("@@ ")
 }
 
-
 /// Looks for lines starting with + or - or space, but not +++ or ---. Not a foolproof check.
 ///
 /// For example, if someone deletes a line that was using the pre-decrement (--) operator or adds a

--- a/tests/parse_samples.rs
+++ b/tests/parse_samples.rs
@@ -20,6 +20,7 @@ fn parse_samples() {
 
         // Make sure that the patch file we produce parses to the same information as the original
         // patch file.
+        #[allow(clippy::format_collect)] // Display::fmt is the only way to resolve Patch->str
         let patch_file: String = patches.iter().map(|patch| format!("{}\n", patch)).collect();
         println!("{}", patch_file);
         let patches2 = Patch::from_multiple(&patch_file).unwrap_or_else(|err| {
@@ -50,6 +51,7 @@ fn parse_wild_samples() {
 
         // Make sure that the patch file we produce parses to the same information as the original
         // patch file.
+        #[allow(clippy::format_collect)] // Display::fmt is the only way to resolve Patch->str
         let patch_file: String = patches.iter().map(|patch| format!("{}\n", patch)).collect();
 
         let patches2 = Patch::from_multiple(&patch_file).unwrap_or_else(|err| {

--- a/tests/parse_samples.rs
+++ b/tests/parse_samples.rs
@@ -50,10 +50,7 @@ fn parse_wild_samples() {
 
         // Make sure that the patch file we produce parses to the same information as the original
         // patch file.
-        let patch_file: String = patches
-            .iter()
-            .map(|patch| format!("{}\n", patch))
-            .collect();
+        let patch_file: String = patches.iter().map(|patch| format!("{}\n", patch)).collect();
 
         let patches2 = Patch::from_multiple(&patch_file).unwrap_or_else(|err| {
             panic!(

--- a/tests/wild-samples/.gitattributes
+++ b/tests/wild-samples/.gitattributes
@@ -1,0 +1,2 @@
+# Disable text processing on these wild sample - eg preserve their wild CRLF format
+*.patch -text


### PR DESCRIPTION
Hi,

I'm looking to coalesce the outstanding patches here and in the upstream as best I can, and eventually resolve some issues with some patches that are failing me.  The first step is to get actions passing again, and lock down some existing desirable existing conditions (pre 2024 edition support for example).

1. Add more platforms 
2. Test with multiple rust versions - important to verify previous edition compatibility for maximum upstream utility
3. Resolve style issues with pickier `fmt` and `clippy` upstream versions
    1. warnings about over-prescriptive lifetimes
    2. warnings about format usage
4. Lock down the CRLF format for "wild-samples" - needed to ensure windows tests pass for wild-patches
5. Allow manual running of workflow on non-main branch