### PR TITLE
restore trailing tab for parser test_headers

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -501,8 +501,10 @@ mod tests {
             File {path: "tzu".into(), meta: None},
         ));
 
+        // note: the trailing tab after lao is intentional and significant here
+        // see https://github.com/uniphil/patch-rs/commit/364897dae8599cdb758c00fdc8dacd1645959070
         let sample2b = "\
---- lao
+--- lao	
 +++ tzu	\n";
         test_parser!(headers(sample2b) -> (
             File {path: "lao".into(), meta: None},

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -1,0 +1,7 @@
+# Tell editors to allow whitespace violations in source
+[parse_patch.rs]
+trim_trailing_whitespace = false
+
+# This shouldn't be needed
+[*.{diff,patch}]
+trim_trailing_whitespace = false

--- a/tests/parse_patch.rs
+++ b/tests/parse_patch.rs
@@ -416,3 +416,37 @@ rename to new-path.rs
     assert_eq!(patches[0].new.path, "new-path.rs");
     assert!(patches[0].hunks.is_empty());
 }
+
+#[test]
+fn binary_diff_interspersed_with_text_diff() {
+    let sample = "\
+--- before.py
++++ after.py
+@@ -1,4 +1,4 @@
+-bacon
+-eggs
+-ham
++python
++eggy
++hamster
+ guido
+Binary files old.bin and new.bin differ
+--- before2.py
++++ after2.py
+@@ -1,4 +1,4 @@
+-bacon
+-eggs
+-ham
++python
++eggy
++hamster
+ guido
+Binary files old2.bin and new2.bin differ
+";
+    let patches = Patch::from_multiple(sample).unwrap();
+    assert_eq!(patches.len(), 4);
+    assert_eq!(patches[0].old.path, "before.py");
+    assert_eq!(patches[1].old.path, "old.bin");
+    assert_eq!(patches[2].new.path, "after2.py");
+    assert_eq!(patches[3].new.path, "new2.bin");
+}


### PR DESCRIPTION
also add one more test for binary differing

---
This pulls in a fix from the original project from https://github.com/uniphil/patch-rs/pull/32/commits/2e82523cecf62c45e5daeb0c07fe8cde22251493

I took the liberty of adding an `.editorconfig` file so that many editors will not strip the whitespace in the future.